### PR TITLE
Update hand wheel encoder hw description

### DIFF
--- a/docs/els.md
+++ b/docs/els.md
@@ -120,7 +120,7 @@ thread pitch you can turn in threading operations. There is currently no warning
 than the minimum required PPR.
 
 * Spindle Encoder: Optical 600PPR, https://www.aliexpress.com/item/4000392086291.html
-* Hand wheel Encoder / pulser 100PPR, https://www.aliexpress.com/item/32949618549.html
+* Hand wheel Encoder / pulser 100PPR 5v 4pin, https://www.aliexpress.com/item/32949618549.html
 
 ### Stepper motor & controller
 


### PR DESCRIPTION
There are a few different options for the hand wheel encoder. According to the schematic, this was built with the 4-wire 5v version in mind.